### PR TITLE
Enable clipboard copy of system

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -305,7 +305,8 @@ button.btn-search, button.btn-reset {
 }
 #system-id {
     font-size: 0.8em;
-    margin-left: 104px;
+    margin-left: 80px;
+	padding-left: 24px;
     text-shadow: 2px 2px #000;
 }
 .system-detail-panel {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -305,9 +305,10 @@ button.btn-search, button.btn-reset {
 }
 #system-id {
     font-size: 0.8em;
-    margin-left: 80px;
-	padding-left: 24px;
+    margin-left: 78px;
+	padding-left: 26px;
     text-shadow: 2px 2px #000;
+	cursor: pointer;
 }
 .system-detail-panel {
     width:96%;

--- a/assets/js/stfc-map.js
+++ b/assets/js/stfc-map.js
@@ -184,9 +184,13 @@ STFCMap = (function() {
             window.status = 'maploaded';
         }).on('popupopen', function() {
 			$('#system-id').click(function(e) {
-				let str = `[${this.dataset.systemName} S:${this.dataset.systemId}]`;
+				let sysName = `${this.dataset.systemName} System`;
+				if (sysName.length > 25) {  //game limit on bookmark names
+					sysName = sysName.substring(0, sysName.length - 1) + '…';
+				}
+				let str = `[${sysName} S:${this.dataset.systemId}]`;
 				copyToClipboard(str);
-				alert(`Copied ${str} to clipboard!`);
+				alert(`Copied "${str}" to the clipboard. Paste it in your game!`);
 			});
 		});
 

--- a/assets/js/stfc-map.js
+++ b/assets/js/stfc-map.js
@@ -182,7 +182,13 @@ STFCMap = (function() {
         }).on('load', function() {
             //if you need to know when the map is finished loading, check window status.
             window.status = 'maploaded';
-        });
+        }).on('popupopen', function() {
+			$('#system-id').click(function(e) {
+				let str = `[${this.dataset.systemName} S:${this.dataset.systemId}]`;
+				copyToClipboard(str);
+				alert(`Copied ${str} to clipboard!`);
+			});
+		});
 
         //hash = new L.Hash(map); //todo - generate hash urls
         let systemsJson = "assets/json/systems.json"; //the galaxy data is here.
@@ -280,7 +286,7 @@ STFCMap = (function() {
                 rare: properties.rareArmadaRange,
                 epic: properties.epicArmadaRange,
             };
-            setEvents(yx, event, eventsGroup, eventData); //set the events object
+            //setEvents(yx, event, eventsGroup, eventData); //set the events object
 
             //cache data for later
             systemIds[id] = name;
@@ -676,12 +682,12 @@ STFCMap = (function() {
         let hostiles = p.hostiles || '';
         let stationHub = p.stationHub;
         //<div>Station Hubs: ${stationHub}</div>
-        let divOpen = `<div class='popup-${popupClass}'>`;
+        let divOpen = `<div class='popup-${popupClass}' data-systemid='${id}'>`;
         let divClose = "</div>";
         let info =
             `<div id="system-zone">${zone} <span id="system-event">${event}</span> </div>
              <div id="system-name">${name} [${systemLevel}]</div>
-             <div id="system-id"><span>S:</span>${id}</div>
+             <div id="system-id" class="clickable" data-system-id="${id}" data-system-name="${name}"><span>S:</span>${id}</div>
              <div class="system-detail-panel">
                  <div><span>Hostiles:</span> <code>${hostiles}</code> </div>
                  <div class="half-size">


### PR DESCRIPTION
This allows users to click a system and use the bookmark button to copy the system to the clipboard, just like they would in-game. The format is compatible so the copied text can also be pasted in-game and will be converted to a link.

To get a local copy of this working on my system I had to comment out stfc-map.js:293.